### PR TITLE
Improve MooX::Cmd

### DIFF
--- a/lib/MooX/Cmd/Role.pm
+++ b/lib/MooX/Cmd/Role.pm
@@ -244,13 +244,13 @@ sub _initialize_from_cmd
 	});
 
 	my @args = $opts_record->records(join(' ',@ARGV));
-	my @used_args;
-	my $cmd;
+	my (@used_args, $cmd, $cmd_name);
 
 	defined $params{command_commands} or $params{command_commands} = $class->_build_command_commands(%params);
 	while (my $arg = shift @args) {
 		push @used_args, $arg and next unless $cmd = $params{command_commands}->{$arg};
 
+		my $cmd_name = $arg; # be careful about relics
 		use_module( $cmd );
 		$cmd->can($execute_method_name)
 		  or croak "you need an '".$execute_method_name."' function in ".$cmd;
@@ -266,7 +266,7 @@ sub _initialize_from_cmd
 	@ARGV = @used_args;
 	$params{command_args} = [ @args ];
 	$params{command_chain} = \@moox_cmd_chain; # later modification hopefully will modify ...
-	$params{command_name} = $cmd;
+	$params{command_name} = $cmd_name;
 	my $self = $creation_method->($class, %params);
 	$cmd and push @moox_cmd_chain, $self;
 


### PR DESCRIPTION
That are two pull requests in one - sorry, but they are so small ;)

First stop 5.18 from whining, second allows apps to show which commands exists (eg. when base class is called without command on cli etc.)
